### PR TITLE
Disable PHP Warning

### DIFF
--- a/src/ReconnectingPDO.php
+++ b/src/ReconnectingPDO.php
@@ -323,7 +323,7 @@ class ReconnectingPDO extends PDO
                 //noop
                 break;
             default:
-                $this->connection->query('SELECT 1');
+                @$this->connection->query('SELECT 1');
                 break;
         }
     }


### PR DESCRIPTION
I'm getting PHP Warning:
```
PHP Warning:  Error while sending QUERY packet. PID=23374 in vendor/legow/reconnecting-pdo/src/ReconnectingPDO.php on line 325
PHP Stack trace:
PHP   1. {main}() src/worker/db_test.php:0
PHP   2. Doctrine\DBAL\Connection->ping() src/worker/db_test.php:46
PHP   3. Doctrine\DBAL\Connection->query() vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1671
PHP   4. LegoW\ReconnectingPDO\ReconnectingPDO->query() vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1010
PHP   5. LegoW\ReconnectingPDO\ReconnectingPDO->call() vendor/legow/reconnecting-pdo/src/ReconnectingPDO.php:287
PHP   6. LegoW\ReconnectingPDO\ReconnectingPDO->ping() vendor/legow/reconnecting-pdo/src/ReconnectingPDO.php:109
PHP   7. PDO->query() vendor/legow/reconnecting-pdo/src/ReconnectingPDO.php:325
```

I've tried to catch it with `set_error_handler` with no luck.

So, let's mute it by adding `@`: `@$this->connection->query('SELECT 1');`