### PR TITLE
prepare() should accept string type

### DIFF
--- a/src/ReconnectingPDO.php
+++ b/src/ReconnectingPDO.php
@@ -181,7 +181,7 @@ class ReconnectingPDO extends PDO
 
     /**
      * Prepares a statement for execution and returns a statement object
-     * @param type $statement
+     * @param string $statement
      * @param array $driver_options [optional]
      * @return ReconnectingPDOStatement|bool
      */


### PR DESCRIPTION
My IDE pointed out that `prepare()` method currently accepts `$statement` with a type called "type", which is incorrect when I try to prepare the string statement (`prepare("SELECT 1");` for example).